### PR TITLE
Migrate to new build structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,5 @@ project(LedBlinkerBase C CXX)
 include("${CMAKE_CURRENT_LIST_DIR}/fprime/cmake/FPrime.cmake")
 include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime-Code.cmake")
 
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components")
+# This includes project-wide objects
+include("${CMAKE_CURRENT_LIST_DIR}/project.cmake")

--- a/LedBlinker/CMakeLists.txt
+++ b/LedBlinker/CMakeLists.txt
@@ -11,9 +11,6 @@
 # Topology and Components
 ###
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Top")
-# Add custom components to this specific deployment here
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../Components")
-
 
 set(SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Main.cpp")
 set(MOD_DEPS ${FPRIME_CURRENT_MODULE}/Top)

--- a/LedBlinker/CMakeLists.txt
+++ b/LedBlinker/CMakeLists.txt
@@ -1,33 +1,21 @@
 #####
 # 'LedBlinker' Deployment:
 #
-# This sets up the build for the 'LedBlinker' Application, including custom
-# components. In addition, it imports FPrime.cmake, which includes the core F Prime components.
+# This registers the 'LedBlinker' deployment to the build system. 
+# Custom components that have not been added at the project-level should be added to 
+# the list below.
 #
 #####
 
 ###
-# Basic Project Setup
+# Topology and Components
 ###
-cmake_minimum_required(VERSION 3.13)
-cmake_policy(SET CMP0048 NEW)
-project(LedBlinker VERSION 1.0.0 LANGUAGES C CXX)
-
-###
-# F' Core Setup
-# This includes all of the F prime core components, and imports the make-system.
-###
-include("${CMAKE_CURRENT_LIST_DIR}/../fprime/cmake/FPrime.cmake")
-# NOTE: register custom targets between these two lines
-include("${FPRIME_FRAMEWORK_PATH}/cmake/FPrime-Code.cmake")
-
-###
-# Components and Topology
-###
-add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../Components")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Top")
+# Add custom components to this specific deployment here
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../Components")
+
 
 set(SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/Main.cpp")
-set(MOD_DEPS ${PROJECT_NAME}/Top)
+set(MOD_DEPS ${FPRIME_CURRENT_MODULE}/Top)
 
 register_fprime_deployment()

--- a/LedBlinker/settings.ini
+++ b/LedBlinker/settings.ini
@@ -1,5 +1,0 @@
-; For more information: https://nasa.github.io/fprime/UsersGuide/user/settings.html
-[fprime]
-project_root: ../
-framework_path: ../fprime
-install_directory: ./build-artifacts

--- a/project.cmake
+++ b/project.cmake
@@ -1,0 +1,5 @@
+# This CMake file is intended to register project-wide objects.
+# This allows for reuse between deployments, or other projects.
+
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/LedBlinker/")


### PR DESCRIPTION
For #6, removed `project` calls from the `LedBlinker` deployment since the new cmake structure is to do any project calls outside of an fprime deployment and within the project root.

I looked through the documentation and didn't see any reference to `project` within deployments, so I don't think any cleanup is needed there. However, I did notice that the `project.cmake` file is missing from the `LedBlinker` deployment and that it is referenced in the [initial integration](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/docs/initial-integration.md#adding-led-component-to-the-deployment) and [component implementation](https://github.com/fprime-community/fprime-workshop-led-blinker/blob/main/docs/component-implementation-1.md#create-the-component) docs. Do we want to add this in?