### PR TITLE
Add override to parameterUpdated

### DIFF
--- a/docs/component-implementation-2.md
+++ b/docs/component-implementation-2.md
@@ -110,7 +110,7 @@ In your `led-blinker/Components/Led` directory, open the file `Led.hpp` and add 
     //! Emit parameter updated EVR
     //!
     void parameterUpdated(FwPrmIdType id /*!< The parameter ID*/
-    );
+    ) override;
 ```
 
 > This function is called when a parameter is updated via the generated SET command. Although the value is updated automatically, this function gives developers a chance to respond to changing parameters. This tutorial uses it to emit an updated Event.


### PR DESCRIPTION
Hey team,

I noticed a warning when following this part of the led blinker tutorial.
```sh
In file included from /Users/nate/code/github.com/nateinaction/fprime-led-blinker/led-blinker/Components/Led/Led.cpp:7:
/Users/nate/code/github.com/nateinaction/fprime-led-blinker/led-blinker/Components/Led/Led.hpp:62:12: warning: 'parameterUpdated' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
      void parameterUpdated(FwPrmIdType id /*!< The parameter ID*/
           ^
/Users/nate/code/github.com/nateinaction/fprime-led-blinker/led-blinker/build-fprime-automatic-native/Components/Led/LedComponentAc.hpp:638:20: note: overridden virtual function is here
      virtual void parameterUpdated(
                   ^
1 warning generated.
```

Adding this override resolves the issue. Thoughts?