### PR TITLE
Update fprime git submodule to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fprime"]
 	path = fprime
-	url = http://github.com/nasa/fprime.git
+	url = https://github.com/nasa/fprime.git
 	branch = devel


### PR DESCRIPTION
Fixes warning:

```
Cloning into '/Users/joshuaa/p/fprime-workshop-led-blinker/fprime'...
warning: redirecting to https://github.com/nasa/fprime.git/
```

