### PR TITLE
Add Dockerfile to for easy building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# fprime items
+logs/
+cmake-build-*
+build-artifacts/
+build-fprime-*
+*-template
+*.template.cpp
+*.template.hpp
+
+# Misc
+/venv/
+/fprime-venv/
+/.idea/
+/.vscode/
+.DS_Store
+*.gcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS cross-compiler-downloader
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+	apt install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		tar \
+		xz-utils && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+ENV ARM_TOOLS_VERSION=11.2-2022.02
+
+FROM --platform=$BUILDPLATFORM cross-compiler-downloader AS amd64-to-arm64
+
+RUN mkdir -p /opt/toolchains && \
+	curl -Ls "https://developer.arm.com/-/media/Files/downloads/gnu/$ARM_TOOLS_VERSION/binrel/gcc-arm-$ARM_TOOLS_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz" | tar -JC /opt/toolchains --strip-components=1 -x
+
+FROM --platform=$BUILDPLATFORM cross-compiler-downloader AS amd64-to-arm
+
+RUN mkdir -p /opt/toolchains && \
+	curl -Ls "https://developer.arm.com/-/media/Files/downloads/gnu/$ARM_TOOLS_VERSION/binrel/gcc-arm-$ARM_TOOLS_VERSION-x86_64-arm-none-linux-gnueabihf.tar.xz" | tar -JC /opt/toolchains --strip-components=1 -x
+
+FROM --platform=$BUILDPLATFORM cross-compiler-downloader AS arm64-to-arm
+
+RUN mkdir -p /opt/toolchains && \
+	curl -Ls "https://developer.arm.com/-/media/Files/downloads/gnu/$ARM_TOOLS_VERSION/binrel/gcc-arm-$ARM_TOOLS_VERSION-aarch64-arm-none-linux-gnueabihf.tar.xz" | tar -JC /opt/toolchains --strip-components=1 -x
+
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+	apt install -y --no-install-recommends \
+		build-essential \
+		cmake\
+		default-jre \
+		python \
+		python3.8-venv && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# create the virtual environment and install the requirements
+COPY fprime/requirements.txt /
+RUN python3 -m venv /opt/venv && \
+	. /opt/venv/bin/activate && \
+	pip install -r requirements.txt
+
+COPY --from=amd64-to-arm64 /opt/toolchains /opt/toolchains/amd64-to-arm64
+COPY --from=amd64-to-arm /opt/toolchains /opt/toolchains/amd64-to-arm
+COPY --from=arm64-to-arm /opt/toolchains /opt/toolchains/arm64-to-arm
+
+# build the project
+COPY . /workspace
+WORKDIR /workspace
+ARG BUILDARCH
+ARG TARGETARCH
+RUN . /opt/venv/bin/activate && \
+	if [ -n "$TARGETARCH" ] && [ "$BUILDARCH" != "$TARGETARCH" ]; then \
+		export ARM_TOOLS_PATH="/opt/toolchains/$BUILDARCH-to-$TARGETARCH"; \
+		if [ "$TARGETARCH" = "arm64" ]; then \
+			export FPRIME_BUILD_TARGET=aarch64-linux; \
+		elif [ "$TARGETARCH" = "arm" ]; then \
+			export FPRIME_BUILD_TARGET=arm-hf-linux; \
+		fi; \
+	fi && \
+	fprime-util generate $FPRIME_BUILD_TARGET && \
+	fprime-util build $FPRIME_BUILD_TARGET 
+
+FROM scratch
+
+COPY --from=builder /workspace/build-artifacts/ .


### PR DESCRIPTION
Hey fprime team,

I attended the workshop at CDW this year with an M1 and made this Dockerfile to help me easily cross compile to arm or arm64 boards like the odriods used at the workshop. This concept uses docker as a build system which isn't my favorite use case (it also doesn't cache the generated files 🙈) but it's easily invoked with:

```
docker build --platform=linux/arm64 --output=build-artifacts-docker .
```

This Dockerfile has been tested on Apple Silicon and _should_ be compatible with Mac/Linux/Windows host machines running on either x86 or arm which would simplify a lot of the cross-compilation documentation around the different tutorials.

Also, I chose the Ubuntu 20.04 base image because the odroids at CDW were running an older kernel version. Not sure what they're running today. 😄 

What do you think?

---

In a broader conversation I'd love to talk about providing a build system with fprime to make it easier to invoke and build for different hardware. While I haven't used it in a C++ project, I've had some experience building with [Bazel](https://bazel.build/). It was a bit overkill for the project I used it in but it seems like the right kind of implementation for fprime and should be extendable by other projects that also adopt Bazel. Feels like a fun project to work on huh? Where do you think is the best place to have this kind of discussion?

Thanks for taking a look at this and have fun at Small Sat!