### PR TITLE
Update LedBlinkerPackets.xml

### DIFF
--- a/LedBlinker/Top/LedBlinkerPackets.xml
+++ b/LedBlinker/Top/LedBlinkerPackets.xml
@@ -48,11 +48,6 @@
         <channel name="systemResources.NON_VOLATILE_FREE"/>
     </packet>
 
-    <packet name="SystemRes2" id="6" level="2">
-        <channel name="systemResources.FRAMEWORK_VERSION"/>
-        <channel name="systemResources.PROJECT_VERSION"/>
-    </packet>
-
     <packet name="SystemRes3" id="7" level="2">
         <channel name="systemResources.CPU"/>
         <channel name="systemResources.CPU_00"/>


### PR DESCRIPTION
Remove systemResources TLM channels from deployment so pr-2866 can run successfully

https://github.com/nasa/fprime/pull/2866