### PR TITLE
fix: align run_handler types in component guide with fprime-util output

### DIFF
--- a/Components/Led/Led.cpp
+++ b/Components/Led/Led.cpp
@@ -40,7 +40,7 @@ void Led ::parameterUpdated(FwPrmIdType id) {
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void Led ::run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
+void Led ::run_handler(FwIndexType portNum, U32 context) {
     // Read back the parameter value
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     U32 interval = this->paramGet_BLINK_INTERVAL(isValid);

--- a/Components/Led/Led.cpp
+++ b/Components/Led/Led.cpp
@@ -18,13 +18,13 @@ Led ::Led(const char* const compName) : LedComponentBase(compName) {}
 Led ::~Led() {}
 
 void Led ::parameterUpdated(FwPrmIdType id) {
-    Fw::ParamValid isValid;
+    Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     switch (id) {
         case PARAMID_BLINK_INTERVAL: {
             // Read back the parameter value
             const U32 interval = this->paramGet_BLINK_INTERVAL(isValid);
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
-            FW_ASSERT(isValid == Fw::ParamValid::VALID, isValid);
+            FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
 
             // Emit the blink interval set event
             this->log_ACTIVITY_HI_BlinkIntervalSet(interval);
@@ -44,9 +44,8 @@ void Led ::run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
     // Read back the parameter value
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     U32 interval = this->paramGet_BLINK_INTERVAL(isValid);
-
-    // Force interval to be 0 when invalid or not set
-    interval = ((isValid == Fw::ParamValid::INVALID) || (isValid == Fw::ParamValid::UNINIT)) ? 0 : interval;
+    FW_ASSERT((isValid != Fw::ParamValid::INVALID) && (isValid != Fw::ParamValid::UNINIT),
+              static_cast<FwAssertArgType>(isValid));
 
     // Only perform actions when set to blinking
     if (this->m_blinking && (interval != 0)) {

--- a/Components/Led/Led.hpp
+++ b/Components/Led/Led.hpp
@@ -41,8 +41,8 @@ class Led : public LedComponentBase {
         //!
         //! Port receiving calls from the rate group
         void
-        run_handler(NATIVE_INT_TYPE portNum,  //!< The port number
-                    NATIVE_UINT_TYPE context  //!< The call order
+        run_handler(FwIndexType portNum,  //!< The port number
+                    U32 context  //!< The call order
                     ) override;
 
     PRIVATE :

--- a/docs/component-implementation-1.md
+++ b/docs/component-implementation-1.md
@@ -157,7 +157,7 @@ Verify your component is building correctly by running the following command in 
 fprime-util build
 ```
 
-Fix any errors that occur before proceeding with the rest of the tutorial.
+> Fix any errors that occur before proceeding with the rest of the tutorial.
 
 ### Component State
 

--- a/docs/component-implementation-2.md
+++ b/docs/component-implementation-2.md
@@ -106,9 +106,8 @@ void Led ::run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
     // Read back the parameter value
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     U32 interval = this->paramGet_BLINK_INTERVAL(isValid);
-
-    // Force interval to be 0 when invalid or not set
-    interval = ((isValid == Fw::ParamValid::INVALID) || (isValid == Fw::ParamValid::UNINIT)) ? 0 : interval;
+    FW_ASSERT((isValid != Fw::ParamValid::INVALID) && (isValid != Fw::ParamValid::UNINIT),
+              static_cast<FwAssertArgType>(isValid));
 
     // Only perform actions when set to blinking
     if (this->m_blinking && (interval != 0)) {
@@ -195,13 +194,13 @@ Save file and in your `led-blinker/Components/Led` directory, open `Led.cpp` and
 
 ```cpp
 void Led ::parameterUpdated(FwPrmIdType id) {
-    Fw::ParamValid isValid;
+    Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     switch (id) {
         case PARAMID_BLINK_INTERVAL: {
             // Read back the parameter value
             const U32 interval = this->paramGet_BLINK_INTERVAL(isValid);
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
-            FW_ASSERT(isValid == Fw::ParamValid::VALID, isValid);
+            FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
 
             // Emit the blink interval set event
             // TODO: Emit an event with, severity activity high, named BlinkIntervalSet that takes in an argument of

--- a/docs/component-implementation-2.md
+++ b/docs/component-implementation-2.md
@@ -75,8 +75,8 @@ In your `led-blinker/Components/Led` directory, open `Led.template.hpp` file and
     //! Handler implementation for run
     //!
     //! Port receiving calls from the rate group
-    void run_handler(NATIVE_INT_TYPE portNum,  //!< The port number
-                     NATIVE_UINT_TYPE context  //!< The call order
+    void run_handler(FwIndexType portNum,  //!< The port number
+                     U32 context  //!< The call order
                      ) override;
 ```
 
@@ -86,7 +86,7 @@ In your `led-blinker/Components/Led` directory, open `Led.template.cpp` file and
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void Led ::run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
+void Led ::run_handler(FwIndexType portNum, U32 context) {
     // TODO
 }
 ```
@@ -102,7 +102,7 @@ Copy the run_handler implementation below into your run_handler. Try filling in 
 >Don't forget to read the code and comments to understand more about how to use F´.
 
 ```cpp
-void Led ::run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
+void Led ::run_handler(FwIndexType portNum, U32 context) {
     // Read back the parameter value
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     U32 interval = this->paramGet_BLINK_INTERVAL(isValid);

--- a/docs/full-integration.md
+++ b/docs/full-integration.md
@@ -51,7 +51,7 @@ This is done by adding the following at the end of the `configureTopology` funct
     }
 ```
 
-And since this code uses `Fw::Logger`, you will need to add the following line near the top of the `Led.cpp` file.
+And since this code uses `Fw::Logger`, you will need to add the following line near the top of the `led-blinker/LedBlinker/Top/LedBlinkerTopology.cpp` file.
 
 ```c++
 #include <Fw/Logger/Logger.hpp>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # Specifying Requirements
 
-In this addendum to the tutorial, you will learn a bit about specifying requirements. Software requirements are derived from higher-level system requirements and represent the detail needed to implement the software.
+In this section to the tutorial, you will learn a bit about specifying requirements. Software requirements are derived from higher-level system requirements and represent the detail needed to implement the software.
 
 ## System Requirements
 

--- a/docs/system-testing.md
+++ b/docs/system-testing.md
@@ -109,13 +109,12 @@ In `test_blinking()`, after turning blinking on, add the following the check tha
 Run `pytest` and make sure the new assertion passes.
 
 Now, add the similar assertion to verify the BlinkingState is set OFF after stopping blinking
+Run `pytest` again. **Notice that this new telemetry check should fail.**
 
 ```python
 # Assert that blink command sets blinking state off
 #TODO: use fprime_test_api.assert_telemetry to check that "LedBlinker.led.BlinkingState" is off
 ```
-
-Run `pytest` again. **Notice that this new telemetry check should fail.**
 
 Events in fprime are emitted immediately, but telemetry is only emitted periodically. In the LedBlinker deployment, telemetry channels are sent once per second.
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -64,14 +64,13 @@ fprime-util check
 
 ## Add a New Test Case
 
-Now that unit tests have been written, we can add our first unit test case. First, remove the default `ToDo` test and add a new test case called `testBlinking`. 
-In `led-blinker/Components/Led/test/ut/LedTester.hpp` rename the declaration for `testToDo` to be `testBlinking` instead:
+Now that unit tests have been written, we can add our first unit test case. First, remove the default `toDo` test and add a new test case called `testBlinking`. In `led-blinker/Components/Led/test/ut/LedTester.hpp` rename the declaration for `toDo` to be `testBlinking` instead:
 
 ```c++
     void testBlinking();
 ```
 
-In `led-blinker/Components/Led/test/ut/LedTester.cpp` rename the definition for `testToDo` to be `testBlinking`:
+In `led-blinker/Components/Led/test/ut/LedTester.cpp` rename the definition for `toDo` to be `testBlinking`:
 
 ```c++
 void LedTester ::testBlinking() {


### PR DESCRIPTION
Fixes #89. Updates `component-implementation-2.md` to match the actual types (`FwIndexType`, `U32`) generated by `fprime-util impl` for `run_handler` parameters, replacing `NATIVE_INT_TYPE` and `NATIVE_UINT_TYPE`.