### PR TITLE
Update instructions for UT creation

### DIFF
--- a/docs/led-blinker.md
+++ b/docs/led-blinker.md
@@ -761,15 +761,22 @@ This exercise will walk through development of basic unit tests for the `Led` co
 
 To start off, use `fprime-util` to generate a unit test outline for the `Led` component.
 
-First, register unit tests for the `Led` component with the build system by adding these lines at the very end of the component `CMakeLists.txt` file in your `led-blinker/Components/Led` directory, **after** the `register_fprime_module()` call.
+First, register unit tests for the `Led` component with the build system by uncommenting the next lines at the very end of the component `CMakeLists.txt` file in your `led-blinker/Components/Led` directory.
 
 ```
 set(UT_SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/Led.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/Led.fpp"
 )
-set(UT_AUTO_HELPERS ON) # Additional Unit-Test autocoding
+set(UT_MOD_DEPS
+  STest
+)
+set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
+> [!NOTE]
+> Keep the next lines commented:  
+> ```#  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTestMain.cpp"```  
+> ```#  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTester.cpp"```
 
 Next, generate a unit test build cache by running the following terminal commands:
 
@@ -789,24 +796,29 @@ To do so, run the implementation command in the terminal within your `led-blinke
 fprime-util impl --ut
 ```
 
-This step should create the files `LedTester.cpp`, `LedTester.hpp`, and `LedTestMain.cpp` in your current directory. Move them to a new subdirectory called `test/ut`.
+This step should create the files `LedTester.template.cpp`, `LedTester.template.hpp`, and `LedTestMain.template.cpp` in `led-blinker/Components/Led/test/ut`.
 
-This is done with:
-```shell
-#In led-blinker/Components/Led
-mkdir -p test/ut
-mv LedTest* test/ut/
+Since this is the start of the test's implementation, we use the generated template files for our initial test implementation. Inside your `led-blinker/Components/Led/test/ut` directory, rename the files removing the `.template` suffix:
+
+```bash
+# In led-blinker/Components/Led/test/ut
+mv LedTester.template.hpp LedTester.hpp
+mv LedTester.template.cpp LedTester.cpp
+mv LedTestMain.template.cpp LedTestMain.cpp
 ```
 
 Next, update the `CMakeLists.txt` file in your `led-blinker/Components/Led` directory to add those files to the list of unit-test source files. That section should look like this:
 
 ```cmake
 set(UT_SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/Led.fpp"
-    "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTestMain.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTester.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/Led.fpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTestMain.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTester.cpp"
 )
-set(UT_AUTO_HELPERS ON) # Additional Unit-Test autocoding
+set(UT_MOD_DEPS
+  STest
+)
+set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
 

--- a/docs/led-blinker.md
+++ b/docs/led-blinker.md
@@ -761,24 +761,7 @@ This exercise will walk through development of basic unit tests for the `Led` co
 
 To start off, use `fprime-util` to generate a unit test outline for the `Led` component.
 
-First, register unit tests for the `Led` component with the build system by uncommenting the next lines at the very end of the component `CMakeLists.txt` file in your `led-blinker/Components/Led` directory.
-
-```
-set(UT_SOURCE_FILES
-  "${CMAKE_CURRENT_LIST_DIR}/Led.fpp"
-)
-set(UT_MOD_DEPS
-  STest
-)
-set(UT_AUTO_HELPERS ON)
-register_fprime_ut()
-```
-> [!NOTE]
-> Keep the next lines commented:  
-> ```#  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTestMain.cpp"```  
-> ```#  "${CMAKE_CURRENT_LIST_DIR}/test/ut/LedTester.cpp"```
-
-Next, generate a unit test build cache by running the following terminal commands:
+First, generate a unit test build cache by running the following terminal commands:
 
 ```shell
 #In led-blinker/Components/Led
@@ -786,7 +769,6 @@ fprime-util generate --ut
 ```
 > [!NOTE]
 > Unit tests run with special build settings and as such need their own build cache generated.
-
 
 Next we will generate unit test template files. This is similar to the component implementations we have run, but will set up the complete unit test harness. 
 
@@ -807,7 +789,7 @@ mv LedTester.template.cpp LedTester.cpp
 mv LedTestMain.template.cpp LedTestMain.cpp
 ```
 
-Next, update the `CMakeLists.txt` file in your `led-blinker/Components/Led` directory to add those files to the list of unit-test source files. That section should look like this:
+Then, register the unit test files with the build system by uncommenting these lines at the very end of the component `CMakeLists.txt` file in your `led-blinker/Components/Led` directory:
 
 ```cmake
 set(UT_SOURCE_FILES


### PR DESCRIPTION
The update is caused by the next issues: 
 nasa/fprime#2997 : the UT files are included into the newly created component's cmake file;
 nasa/fprime#2515 : the UT templates are generated and moved into `test/ut` by the `fprime-util impl --ut`.