### PR TITLE
Add namespace to Project Setup

### DIFF
--- a/docs/led-blinker.md
+++ b/docs/led-blinker.md
@@ -65,7 +65,7 @@ An F´ Project ties to a specific version of tools to work with F´. In order to
 this project and install the correct version of tools, you should perform a bootstrap of F´:
 
 1. Ensure you meet the [F´ System Requirements](https://github.com/nasa/fprime?tab=readme-ov-file#system-requirements)
-2. [Bootstrap your F´ project](https://fprime.jpl.nasa.gov/latest/docs/getting-started/installing-fprime/#creating-a-new-f-project) with the name `led-blinker`
+2. [Bootstrap your F´ project](https://fprime.jpl.nasa.gov/latest/docs/getting-started/installing-fprime/#creating-a-new-f-project) with the name `led-blinker` and namespace 'LedBlinker'
 
 Bootstrapping your F´ project created a folder called `led-blinker` (or any name you chose) containing the standard F´ project structure as well as the virtual environment up containing the tools to work with F´.
 


### PR DESCRIPTION
@kevin-f-ortega @thomas-bc In the devel docs for Led Blinker it does not mention the namespace update to bootstrap in the Project Setup. This PR adds the 'LedBlinker' namespace specification to the same step as the 'led-blinker' project name specification in step 2.